### PR TITLE
Fix spdlog issues on gnuradio 3.11

### DIFF
--- a/lib/bbheader_bb_impl.cc
+++ b/lib/bbheader_bb_impl.cc
@@ -503,8 +503,7 @@ namespace gr {
             for (int j = 0; j < (int)((kbch[i] - 80) / 8); j++) {
               if (count[i] == 0) {
                 if (*in != 0x47) {
-                  GR_LOG_WARN(d_logger, boost::format("Transport Stream %1% sync error!") \
-                              % i);
+                  d_logger->warn("Transport Stream {} sync error!",i);
                 }
                 in++;
                 b = crc[i];
@@ -528,8 +527,7 @@ namespace gr {
               if (nibble[i] == TRUE) {
                 if (count[i] == 0) {
                   if (*in != 0x47) {
-                    GR_LOG_WARN(d_logger, boost::format("Transport Stream %1% sync error!") \
-                                % i);
+                    d_logger->warn("Transport Stream {} sync error!",i);
                   }
                   in++;
                   b = crc[i];

--- a/lib/bbheader_source_impl.cc
+++ b/lib/bbheader_source_impl.cc
@@ -1089,7 +1089,7 @@ namespace gr {
               d_socket->send_to(boost::asio::buffer((void*)(udp_packet), (kbch[i] / 8) + 4), d_endpoint);
             }
             catch(std::exception& e) {
-              GR_LOG_ERROR(d_logger, boost::format("send error: %s") % e.what());
+              d_logger->error("send error: {}",e.what());
             }
           }
         }


### PR DESCRIPTION
This fixes the error with updated spdlog versions on gnuradio 3.11:

`/home/bjk/gnuradio/src/modules/gr-dvbs2/lib/bbheader_bb_impl.cc:506:19:   required from here
/usr/include/fmt/core.h:1757:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1757 |       formattable,
      |       ^~~~~~~~~~~
`